### PR TITLE
Add segment name to error message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(real_time_tools REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(cereal REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem system thread)
+find_package(fmt REQUIRED)
 
 ament_export_dependencies(
   mpi_cmake_modules
@@ -29,7 +30,9 @@ ament_export_dependencies(
   shared_memory
   real_time_tools
   cereal
-  Boost)
+  Boost
+  fmt
+)
 
 
 # prepare to export all needed targets
@@ -52,6 +55,7 @@ target_include_directories(
 ament_target_dependencies(${PROJECT_NAME} cereal)
 target_link_libraries(${PROJECT_NAME} shared_memory::shared_memory)
 target_link_libraries(${PROJECT_NAME} real_time_tools::real_time_tools)
+target_link_libraries(${PROJECT_NAME} fmt::fmt)
 ament_export_interfaces(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 list(APPEND all_targets ${PROJECT_NAME})
 list(APPEND all_target_exports export_${PROJECT_NAME})

--- a/src/leader_sync.cpp
+++ b/src/leader_sync.cpp
@@ -1,5 +1,7 @@
 #include "synchronizer/private/leader_sync.hpp"
 
+#include <fmt/format.h>
+
 namespace synchronizer
 {
 Leader_sync::Leader_sync(std::string memory_segment, bool sync_on_start)
@@ -16,11 +18,11 @@ Leader_sync::Leader_sync(std::string memory_segment, bool sync_on_start)
     }
     catch (...)
     {
-        throw std::runtime_error(
-            std::string(
-                "synchronizer::Leader should be started after an instance") +
-            std::string(" of synchronizer::Follower of the same memory segment "
-                        "has been started"));
+        throw std::runtime_error(fmt::format(
+            "synchronizer::Leader for memory segment '{}' should be started "
+            "after an instance of synchronizer::Follower of the same memory "
+            "segment has been started.",
+            memory_segment));
     }
 
     if (sync_on_start)


### PR DESCRIPTION
## Description

Add the name of the memory segment to the "Leader should be started after Follower" error message.  This makes it easier to see where the error is coming from in a setup with different Leaders/Followers.

Use the fmt library (new dependency) for more nicely inserting the name into the string.


## How I Tested

Added some test code that throws an exception to make sure the error message looks good.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
